### PR TITLE
fix: avoid modification timestamp changed in bindata.go

### DIFF
--- a/Makefile.expansion
+++ b/Makefile.expansion
@@ -9,4 +9,8 @@ pre-build:
 	if [[ -n "$(diff $(TEMP_DIR)/caimake.sh hack/caimake/caimake.sh)" ]]; then \
 		mv $(TEMP_DIR)/caimake.sh hack/caimake/caimake.sh; \
 	fi
-	go-bindata -ignore DS_Store -pkg cmd -o pkg/caimake/cmd/bindata.go -prefix hack/caimake hack/caimake/... 
+	go-bindata -modtime 1 -ignore DS_Store -pkg cmd -o pkg/caimake/cmd/bindata.go -prefix hack/caimake hack/caimake/... 
+
+.PHONY: go-bindata
+go-bindata:
+	go get -u github.com/jteeuwen/go-bindata/...

--- a/pkg/caimake/cmd/bindata.go
+++ b/pkg/caimake/cmd/bindata.go
@@ -85,7 +85,7 @@ func makefileGoTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "Makefile.go.tmpl", size: 8684, mode: os.FileMode(420), modTime: time.Unix(1521726872, 0)}
+	info := bindataFileInfo{name: "Makefile.go.tmpl", size: 8684, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -105,7 +105,7 @@ func caimakeSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "caimake.sh", size: 37798, mode: os.FileMode(493), modTime: time.Unix(1522682435, 0)}
+	info := bindataFileInfo{name: "caimake.sh", size: 37798, mode: os.FileMode(493), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -125,7 +125,7 @@ func updateSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "update.sh", size: 2525, mode: os.FileMode(420), modTime: time.Unix(1521726872, 0)}
+	info := bindataFileInfo{name: "update.sh", size: 2525, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

persist modification timestamp to 1 in go-bindata, avoiding it changing after PR merged

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

/cc @your-reviewer

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix: avoid modification timestamp changed in bindata.go
```
